### PR TITLE
feat: implement browser-based weather dashboard

### DIFF
--- a/__tests__/fetchWeather.test.js
+++ b/__tests__/fetchWeather.test.js
@@ -1,43 +1,59 @@
 const { fetchWeather } = require('../fetchWeather');
 
-// Mock fetch
 global.fetch = jest.fn();
 
-test('fetchWeather returns expected summary and label', async () => {
+test('fetchWeather aggregates data and returns summary', async () => {
   const city = 'Testville';
   const start = '2023-01-01';
   const end = '2023-01-03';
 
-  // Mock geo API response
+  // geo
   fetch.mockResolvedValueOnce({
-    json: async () => ({
-      results: [
-        { latitude: 1, longitude: 2, name: 'Testville', country: 'TV' }
-      ]
-    })
+    json: async () => ({ results: [{ latitude:1, longitude:2, name:'Testville', country:'TV' }] })
   });
-
-  // Mock weather API response
+  // daily
   fetch.mockResolvedValueOnce({
     json: async () => ({
       daily: {
         time: [start, '2023-01-02', end],
-        temperature_2m_min: [1, 2, 3],
-        temperature_2m_mean: [2, 3, 4],
-        temperature_2m_max: [3, 4, 5],
-        precipitation_sum: [0, 1, 2]
+        temperature_2m_min: [1,2,3],
+        temperature_2m_mean: [2,3,4],
+        temperature_2m_max: [3,4,5],
+        precipitation_sum: [0,1,2],
+        windspeed_10m_max: [10,12,15]
       }
+    })
+  });
+  // hourly
+  fetch.mockResolvedValueOnce({
+    json: async () => ({
+      hourly: {
+        time: [
+          start+'T00', start+'T12',
+          '2023-01-02T00', '2023-01-02T12',
+          end+'T00', end+'T12'
+        ],
+        relative_humidity_2m: [70,80,60,65,50,55],
+        windspeed_10m: [5,10,6,12,7,14]
+      }
+    })
+  });
+  // normals
+  fetch.mockResolvedValueOnce({
+    json: async () => ({
+      monthly: { temperature_2m_mean: [1,2,3,4,5,6,7,8,9,10,11,12] }
     })
   });
 
   const data = await fetchWeather(city, start, end);
 
-  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(fetch).toHaveBeenCalledTimes(4);
   expect(data.label).toBe('Testville, TV (' + start + ' – ' + end + ')');
-  expect(data.summary).toEqual({
-    minTemp: 1,
-    maxTemp: 5,
-    avgTemp: (2 + 3 + 4) / 3,
-    totalPrec: 3
-  });
+  expect(data.summary.minTemp).toBe(1);
+  expect(data.summary.maxTemp).toBe(5);
+  expect(data.summary.avgTemp).toBe((2+3+4)/3);
+  expect(data.summary.totalPrec).toBe(3);
+  expect(data.summary.humAvg).toBeCloseTo((75+62.5+52.5)/3);
+  expect(data.summary.windAvg).toBeCloseTo((7.5+9+10.5)/3);
+  expect(data.summary.windMax).toBe(15);
 });

--- a/fetchWeather.js
+++ b/fetchWeather.js
@@ -1,43 +1,142 @@
+function dailyMeanFromHourly(times, values) {
+  const days = [];
+  const means = [];
+  let currentDay = null;
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < times.length; i++) {
+    const day = times[i].slice(0, 10);
+    if (currentDay === null) currentDay = day;
+    if (day !== currentDay) {
+      days.push(currentDay);
+      means.push(count ? sum / count : null);
+      currentDay = day;
+      sum = 0;
+      count = 0;
+    }
+    const v = values[i];
+    if (typeof v === 'number') {
+      sum += v;
+      count++;
+    }
+  }
+  if (currentDay !== null) {
+    days.push(currentDay);
+    means.push(count ? sum / count : null);
+  }
+  return { days, means };
+}
+
+async function fetchNormals(lat, lon) {
+  const url = `https://climate-api.open-meteo.com/v1/climate?latitude=${lat}&longitude=${lon}&start_year=1991&end_year=2020&monthly=temperature_2m_mean`;
+  const res = await fetch(url);
+  const json = await res.json();
+  if (!json.monthly || !json.monthly.temperature_2m_mean) {
+    throw new Error('No climate normals');
+  }
+  const temps = json.monthly.temperature_2m_mean; // 12 values
+  const daysPerMonth = [31,28,31,30,31,30,31,31,30,31,30,31];
+  const doy = [];
+  const vals = [];
+  for (let m = 0; m < 12; m++) {
+    const startT = temps[m];
+    const endT = temps[(m + 1) % 12];
+    const len = daysPerMonth[m];
+    for (let d = 0; d < len; d++) {
+      const frac = d / len;
+      vals.push(startT + (endT - startT) * frac);
+      doy.push(vals.length);
+    }
+  }
+  // insert leap day duplicate of Feb 28
+  vals.splice(59, 0, vals[58]);
+  doy.splice(59, 0, 60);
+  return { doy, tmeanNorm: vals };
+}
+
+function mean(arr) {
+  return arr.reduce((a, b) => a + b, 0) / (arr.length || 1);
+}
+
+function sum(arr) {
+  return arr.reduce((a, b) => a + b, 0);
+}
+
+function getDOY(date) {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), 0, 0));
+  return Math.floor((date - start) / 86400000);
+}
+
 async function fetchWeather(city, start, end) {
   if (!city || !start || !end) {
-    throw new Error("Не заполнены все поля для " + city);
+    throw new Error('City, start and end are required');
   }
-
-  const geoUrl = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1&language=ru&format=json`;
+  const geoUrl = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1&language=en`;
   const geoRes = await fetch(geoUrl);
   const geoJson = await geoRes.json();
   if (!geoJson.results || !geoJson.results.length) {
-    throw new Error("Город не найден: " + city);
+    throw new Error('City not found: ' + city);
   }
   const { latitude, longitude, name, country } = geoJson.results[0];
 
-  const weatherUrl = `https://archive-api.open-meteo.com/v1/archive?latitude=${latitude}&longitude=${longitude}&start_date=${start}&end_date=${end}&daily=temperature_2m_min,temperature_2m_mean,temperature_2m_max,precipitation_sum&timezone=UTC`;
-  const wxRes = await fetch(weatherUrl);
-  const wxJson = await wxRes.json();
-  if (!wxJson || !wxJson.daily) {
-    throw new Error("Нет данных погоды для " + city);
+  const dailyUrl = `https://archive-api.open-meteo.com/v1/era5?latitude=${latitude}&longitude=${longitude}&start_date=${start}&end_date=${end}&daily=temperature_2m_min,temperature_2m_mean,temperature_2m_max,precipitation_sum,windspeed_10m_max&timezone=UTC`;
+  const dailyRes = await fetch(dailyUrl);
+  const dailyJson = await dailyRes.json();
+  if (!dailyJson || !dailyJson.daily) {
+    throw new Error('No weather data for ' + city);
+  }
+  const daily = dailyJson.daily;
+
+  const hourlyUrl = `https://archive-api.open-meteo.com/v1/era5?latitude=${latitude}&longitude=${longitude}&start_date=${start}&end_date=${end}&hourly=relative_humidity_2m,windspeed_10m&timezone=UTC`;
+  const hourlyRes = await fetch(hourlyUrl);
+  const hourlyJson = await hourlyRes.json();
+  const humAgg = dailyMeanFromHourly(hourlyJson.hourly.time, hourlyJson.hourly.relative_humidity_2m);
+  const windAgg = dailyMeanFromHourly(hourlyJson.hourly.time, hourlyJson.hourly.windspeed_10m);
+
+  let normals = null;
+  try {
+    normals = await fetchNormals(latitude, longitude);
+  } catch (e) {
+    normals = null;
   }
 
-  const dates = wxJson.daily.time;
-  const min = wxJson.daily.temperature_2m_min;
-  const mean = wxJson.daily.temperature_2m_mean;
-  const max = wxJson.daily.temperature_2m_max;
-  const prec = wxJson.daily.precipitation_sum;
+  const minTemp = Math.min(...daily.temperature_2m_min);
+  const maxTemp = Math.max(...daily.temperature_2m_max);
+  const avgTemp = mean(daily.temperature_2m_mean);
+  const totalPrec = sum(daily.precipitation_sum);
+  const humAvg = mean(humAgg.means);
+  const windAvg = mean(windAgg.means);
+  const windMax = Math.max(...daily.windspeed_10m_max);
 
-  const minTemp = Math.min(...min);
-  const maxTemp = Math.max(...max);
-  const avgTemp = mean.reduce((acc, v) => acc + v, 0) / (mean.length || 1);
-  const totalPrec = prec.reduce((acc, v) => acc + v, 0);
+  let climateDev = null;
+  if (normals) {
+    const normSlice = daily.time.map(t => {
+      const d = new Date(t);
+      return normals.tmeanNorm[getDOY(d) - 1];
+    });
+    climateDev = avgTemp - mean(normSlice);
+  }
 
   return {
     label: `${name.trim()}, ${country} (${start} – ${end})`,
-    dates,
-    min,
-    mean,
-    max,
-    prec,
-    summary: { minTemp, maxTemp, avgTemp, totalPrec },
+    dates: daily.time,
+    min: daily.temperature_2m_min,
+    mean: daily.temperature_2m_mean,
+    max: daily.temperature_2m_max,
+    prec: daily.precipitation_sum,
+    humidity: humAgg.means,
+    wind: windAgg.means,
+    summary: {
+      minTemp,
+      maxTemp,
+      avgTemp,
+      totalPrec,
+      humAvg,
+      windAvg,
+      windMax,
+      climateDev,
+    },
   };
 }
 
-module.exports = { fetchWeather };
+module.exports = { fetchWeather, dailyMeanFromHourly, fetchNormals };

--- a/index.html
+++ b/index.html
@@ -1,238 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Weather Comparator</title>
-  <!-- Tailwind CSS for quick, responsive layout -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
-      rel="stylesheet"
-    />
-  <!-- Chart.js for visualizations -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  </head>
-  <body class="bg-gray-50 text-gray-900 min-h-screen">
-    <div class="container mx-auto p-6">
-      <h1 class="text-3xl font-bold mb-6 text-center">Weather Comparator</h1>
-
-      <!-- Input panel -->
-      <div class="grid md:grid-cols-2 gap-6 mb-8">
-        <!-- Pair A -->
-        <div class="p-4 bg-white rounded-2xl shadow-sm">
-          <h2 class="text-xl font-semibold mb-2">Пара A</h2>
-          <label class="block mb-1 text-sm font-medium" for="cityA">Город</label>
-          <input
-            id="cityA"
-            type="text"
-            placeholder="Минск"
-            class="w-full p-2 border rounded-lg mb-3"
-          />
-
-          <div class="grid grid-cols-2 gap-2">
-            <div>
-              <label class="block mb-1 text-sm font-medium" for="startA">С даты</label>
-              <input id="startA" type="date" class="w-full p-2 border rounded-lg" />
-            </div>
-            <div>
-              <label class="block mb-1 text-sm font-medium" for="endA">По дату</label>
-              <input id="endA" type="date" class="w-full p-2 border rounded-lg" />
-            </div>
-          </div>
-        </div>
-
-        <!-- Pair B -->
-        <div class="p-4 bg-white rounded-2xl shadow-sm">
-          <h2 class="text-xl font-semibold mb-2">Пара B</h2>
-          <label class="block mb-1 text-sm font-medium" for="cityB">Город</label>
-          <input
-            id="cityB"
-            type="text"
-            placeholder="Вильнюс"
-            class="w-full p-2 border rounded-lg mb-3"
-          />
-
-          <div class="grid grid-cols-2 gap-2">
-            <div>
-              <label class="block mb-1 text-sm font-medium" for="startB">С даты</label>
-              <input id="startB" type="date" class="w-full p-2 border rounded-lg" />
-            </div>
-            <div>
-              <label class="block mb-1 text-sm font-medium" for="endB">По дату</label>
-              <input id="endB" type="date" class="w-full p-2 border rounded-lg" />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <button
-        id="compareBtn"
-        class="block mx-auto bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-6 rounded-xl shadow-md transition"
-      >
-        Сравнить
-      </button>
-
-      <!-- Charts -->
-      <div class="mt-10 space-y-10">
-        <canvas id="tempChart"></canvas>
-        <canvas id="precChart"></canvas>
-      </div>
-
-      <!-- Summary metrics -->
-      <div id="summary" class="mt-10 grid md:grid-cols-2 gap-6"></div>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Grain of Rain</title>
+  <style>
+    body,html{margin:0;padding:0;height:100%;font-family:sans-serif;}
+    #container{display:flex;height:100vh;}
+    #charts{flex:7;display:flex;flex-direction:column;}
+    .chart{flex:1;}
+    #sidebar{flex:3;display:flex;flex-direction:column;}
+    #controls{padding:10px;}
+    #stats{flex:1;overflow:auto;padding:10px;}
+    table{width:100%;border-collapse:collapse;}
+    th{text-align:left;}
+    td,th{padding:2px 4px;}
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  <script type="module" src="./js/ui.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="charts">
+    <div id="chart-temp" class="chart"></div>
+    <div id="chart-precip" class="chart"></div>
+    <div id="chart-humidity" class="chart"></div>
+    <div id="chart-wind" class="chart"></div>
+  </div>
+  <div id="sidebar">
+    <div id="controls">
+      <div><input id="city" placeholder="City" /></div>
+      <div><input id="start" type="date" /> <input id="end" type="date" /></div>
+      <button id="apply">Apply</button>
+      <button id="export">Export PNG</button>
     </div>
-
-    <script>
-      // Declare chart instances only once globally
-      let tempChart;
-      let precChart;
-
-      async function fetchWeather(city, start, end) {
-        if (!city || !start || !end) {
-          throw new Error("Не заполнены все поля для " + city);
-        }
-
-        const geoUrl = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
-          city
-        )}&count=1&language=ru&format=json`;
-        const geoRes = await fetch(geoUrl);
-        const geoJson = await geoRes.json();
-        if (!geoJson.results || !geoJson.results.length) {
-          throw new Error("Город не найден: " + city);
-        }
-        const { latitude, longitude, name, country } = geoJson.results[0];
-
-        const weatherUrl = `https://archive-api.open-meteo.com/v1/archive?latitude=${latitude}&longitude=${longitude}&start_date=${start}&end_date=${end}&daily=temperature_2m_min,temperature_2m_mean,temperature_2m_max,precipitation_sum&timezone=UTC`;
-        const wxRes = await fetch(weatherUrl);
-        const wxJson = await wxRes.json();
-        if (!wxJson || !wxJson.daily) {
-          throw new Error("Нет данных погоды для " + city);
-        }
-
-        const dates = wxJson.daily.time;
-        const min = wxJson.daily.temperature_2m_min;
-        const mean = wxJson.daily.temperature_2m_mean;
-        const max = wxJson.daily.temperature_2m_max;
-        const prec = wxJson.daily.precipitation_sum;
-
-        const minTemp = Math.min(...min);
-        const maxTemp = Math.max(...max);
-        const avgTemp = mean.reduce((acc, v) => acc + v, 0) / (mean.length || 1);
-        const totalPrec = prec.reduce((acc, v) => acc + v, 0);
-
-        return {
-          label: `${name.trim()}, ${country} (${start} – ${end})`,
-          dates,
-          min,
-          mean,
-          max,
-          prec,
-          summary: { minTemp, maxTemp, avgTemp, totalPrec },
-        };
-      }
-
-      function destroyIfExists(chart) {
-        if (chart) {
-          chart.destroy();
-        }
-      }
-
-      function buildCharts(dataA, dataB) {
-        destroyIfExists(tempChart);
-        destroyIfExists(precChart);
-
-        const labels = dataA.dates.length >= dataB.dates.length ? dataA.dates : dataB.dates;
-
-        const ctxTemp = document.getElementById("tempChart").getContext("2d");
-        tempChart = new Chart(ctxTemp, {
-          type: "line",
-          data: {
-            labels,
-            datasets: [
-              { label: "Avg Temp — " + dataA.label, data: dataA.mean, yAxisID: "y", borderWidth: 2, tension: 0.3 },
-              { label: "Avg Temp — " + dataB.label, data: dataB.mean, yAxisID: "y", borderWidth: 2, tension: 0.3 },
-              { label: "Min Temp — " + dataA.label, data: dataA.min, yAxisID: "y", borderWidth: 1, borderDash: [4, 2], tension: 0.3 },
-              { label: "Max Temp — " + dataA.label, data: dataA.max, yAxisID: "y", borderWidth: 1, borderDash: [4, 2], tension: 0.3 },
-              { label: "Min Temp — " + dataB.label, data: dataB.min, yAxisID: "y", borderWidth: 1, borderDash: [4, 2], tension: 0.3 },
-              { label: "Max Temp — " + dataB.label, data: dataB.max, yAxisID: "y", borderWidth: 1, borderDash: [4, 2], tension: 0.3 },
-            ],
-          },
-          options: {
-            interaction: { intersect: false, mode: "index" },
-            scales: {
-              y: { title: { display: true, text: "Температура (°C)" } },
-            },
-          },
-        });
-
-        const ctxPrec = document.getElementById("precChart").getContext("2d");
-        precChart = new Chart(ctxPrec, {
-          type: "bar",
-          data: {
-            labels,
-            datasets: [
-              { label: "Осадки — " + dataA.label, data: dataA.prec, yAxisID: "y1" },
-              { label: "Осадки — " + dataB.label, data: dataB.prec, yAxisID: "y1" },
-            ],
-          },
-          options: {
-            interaction: { intersect: false, mode: "index" },
-            scales: {
-              y1: { beginAtZero: true, title: { display: true, text: "Осадки (мм)" } },
-            },
-          },
-        });
-      }
-
-      function updateSummary(dataA, dataB) {
-        const summaryEl = document.getElementById("summary");
-        summaryEl.innerHTML = "";
-
-        [
-          { label: dataA.label, sum: dataA.summary },
-          { label: dataB.label, sum: dataB.summary },
-        ].forEach((item) => {
-          const card = document.createElement("div");
-          card.className = "p-4 bg-white rounded-2xl shadow-sm";
-          card.innerHTML = `
-            <h3 class="font-semibold mb-2 text-lg">${item.label}</h3>
-            <ul class="space-y-1 text-sm">
-              <li>Мин. темп: <span class="font-mono">${item.sum.minTemp.toFixed(1)} °C</span></li>
-              <li>Макс. темп: <span class="font-mono">${item.sum.maxTemp.toFixed(1)} °C</span></li>
-              <li>Сред. темп: <span class="font-mono">${item.sum.avgTemp.toFixed(1)} °C</span></li>
-              <li>Сумма осадков: <span class="font-mono">${item.sum.totalPrec.toFixed(1)} мм</span></li>
-            </ul>
-          `;
-          summaryEl.appendChild(card);
-        });
-      }
-
-      document.getElementById("compareBtn").addEventListener("click", async () => {
-        const cityA = document.getElementById("cityA").value.trim();
-        const startA = document.getElementById("startA").value;
-        const endA = document.getElementById("endA").value;
-        const cityB = document.getElementById("cityB").value.trim();
-        const startB = document.getElementById("startB").value;
-        const endB = document.getElementById("endB").value;
-
-        if (!cityA || !startA || !endA || !cityB || !startB || !endB) {
-          alert("Пожалуйста, заполните все поля для обеих пар.");
-          return;
-        }
-
-        try {
-          const [dataA, dataB] = await Promise.all([
-            fetchWeather(cityA, startA, endA),
-            fetchWeather(cityB, startB, endB),
-          ]);
-
-          buildCharts(dataA, dataB);
-          updateSummary(dataA, dataB);
-        } catch (err) {
-          console.error(err);
-          alert(err.message || "Ошибка получения данных");
-        }
-      });
-    </script>
-  </body>
+    <div id="stats"></div>
+  </div>
+</div>
+</body>
 </html>

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,85 @@
+const GEO_URL = 'https://geocoding-api.open-meteo.com/v1/search';
+const ERA_URL = 'https://archive-api.open-meteo.com/v1/era5';
+
+export async function searchCity(name) {
+  const url = `${GEO_URL}?name=${encodeURIComponent(name)}&count=1&language=en`;
+  const res = await fetch(url);
+  const json = await res.json();
+  const r = json.results && json.results[0];
+  if (!r) throw new Error('City not found');
+  return { name: r.name, lat: r.latitude, lon: r.longitude, country: r.country };
+}
+
+export async function fetchDaily(lat, lon, start, end) {
+  const url = `${ERA_URL}?latitude=${lat}&longitude=${lon}&start_date=${start}&end_date=${end}&daily=temperature_2m_max,temperature_2m_min,temperature_2m_mean,precipitation_sum,windspeed_10m_max&timezone=UTC`;
+  const res = await fetch(url);
+  const json = await res.json();
+  return {
+    date: json.daily.time,
+    tmin: json.daily.temperature_2m_min,
+    tmean: json.daily.temperature_2m_mean,
+    tmax: json.daily.temperature_2m_max,
+    precip: json.daily.precipitation_sum,
+    windMax: json.daily.windspeed_10m_max
+  };
+}
+
+export async function fetchHourly(lat, lon, start, end) {
+  const url = `${ERA_URL}?latitude=${lat}&longitude=${lon}&start_date=${start}&end_date=${end}&hourly=relative_humidity_2m,windspeed_10m&timezone=UTC`;
+  const res = await fetch(url);
+  const json = await res.json();
+  return {
+    time: json.hourly.time,
+    humidity: json.hourly.relative_humidity_2m,
+    wind: json.hourly.windspeed_10m
+  };
+}
+
+export function dailyMeanFromHourly(time, values) {
+  const days = [];
+  const means = [];
+  let current = null;
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < time.length; i++) {
+    const d = time[i].slice(0,10);
+    if (current === null) current = d;
+    if (d !== current) {
+      days.push(current);
+      means.push(count ? sum / count : null);
+      current = d;
+      sum = 0;
+      count = 0;
+    }
+    const v = values[i];
+    if (typeof v === 'number') { sum += v; count++; }
+  }
+  if (current !== null) {
+    days.push(current);
+    means.push(count ? sum / count : null);
+  }
+  return { days, means };
+}
+
+export async function fetchNormals(lat, lon) {
+  const url = `https://climate-api.open-meteo.com/v1/climate?latitude=${lat}&longitude=${lon}&start_year=1991&end_year=2020&monthly=temperature_2m_mean`;
+  const res = await fetch(url);
+  const json = await res.json();
+  const temps = json.monthly.temperature_2m_mean;
+  const daysPerMonth = [31,28,31,30,31,30,31,31,30,31,30,31];
+  const vals = [];
+  const doy = [];
+  for (let m=0;m<12;m++) {
+    const startT = temps[m];
+    const endT = temps[(m+1)%12];
+    const len = daysPerMonth[m];
+    for (let d=0; d<len; d++) {
+      const frac = d/len;
+      vals.push(startT + (endT-startT)*frac);
+      doy.push(vals.length);
+    }
+  }
+  vals.splice(59,0,vals[58]);
+  doy.splice(59,0,60);
+  return { doy, tmeanNorm: vals };
+}

--- a/js/charts.js
+++ b/js/charts.js
@@ -1,0 +1,43 @@
+export function initCharts() {
+  const temp = echarts.init(document.getElementById('chart-temp'));
+  const precip = echarts.init(document.getElementById('chart-precip'));
+  const humidity = echarts.init(document.getElementById('chart-humidity'));
+  const wind = echarts.init(document.getElementById('chart-wind'));
+  echarts.connect([temp, precip, humidity, wind]);
+  return { temp, precip, humidity, wind };
+}
+
+export function renderAll(ch, series, color = '#1E88E5', prefs = {showGrid:true}) {
+  const x = series.x;
+  const grid = { left: 40, right: 10, top: 10, bottom: 20 };
+  const common = { animation:false, xAxis:{type:'category', data:x, boundaryGap:false}, yAxis:{type:'value'}, grid, tooltip:{trigger:'axis'} };
+  ch.temp.setOption({
+    ...common,
+    yAxis:{type:'value', name:'°C'},
+    series:[
+      {name:'Mean', type:'line', data:series.tempMean, lineStyle:{color, width:2}},
+      {name:'Min', type:'line', data:series.tempMin, lineStyle:{opacity:0}, stack:'temp', areaStyle:{color, opacity:0.2}},
+      {name:'Max', type:'line', data:series.tempMax, lineStyle:{opacity:0}, stack:'temp', areaStyle:{color, opacity:0.2}}
+    ]
+  });
+  if (series.norm) {
+    const opt = ch.temp.getOption();
+    opt.series.push({name:'Norm', type:'line', data:series.norm, lineStyle:{color:'#616161', type:'dotted'}});
+    ch.temp.setOption(opt);
+  }
+  ch.precip.setOption({
+    ...common,
+    yAxis:{type:'value', name:'mm'},
+    series:[{name:'Precip', type:'bar', data:series.precip, itemStyle:{color:`${color}99`}}]
+  });
+  ch.humidity.setOption({
+    ...common,
+    yAxis:{type:'value', name:'%'},
+    series:[{name:'Humidity', type:'line', data:series.humidity, areaStyle:{color:`${color}33`}, lineStyle:{color}}]
+  });
+  ch.wind.setOption({
+    ...common,
+    yAxis:{type:'value', name:'km/h'},
+    series:[{name:'Wind', type:'line', data:series.wind, lineStyle:{color}}]
+  });
+}

--- a/js/export.js
+++ b/js/export.js
@@ -1,0 +1,9 @@
+export async function exportPng(containerId, filename='charts.png') {
+  const node = document.getElementById(containerId);
+  if (!node) return;
+  const canvas = await html2canvas(node);
+  const a = document.createElement('a');
+  a.href = canvas.toDataURL('image/png');
+  a.download = filename;
+  a.click();
+}

--- a/js/store.js
+++ b/js/store.js
@@ -1,0 +1,29 @@
+export function defaultState() {
+  const today = new Date().toISOString().slice(0,10);
+  const yearEnd = today.slice(0,4) + '-12-31';
+  return {
+    mode: 'overview',
+    entities: [],
+    periods: [],
+    date: { start: today, end: yearEnd },
+    prefs: { showNormals: true, showAllBands: false, showGrid: true }
+  };
+}
+
+export function loadState() {
+  try {
+    const raw = localStorage.getItem('gor:v1');
+    if (raw) return JSON.parse(raw);
+  } catch (e) {
+    console.warn('Failed to load state', e);
+  }
+  return defaultState();
+}
+
+export function saveState(state) {
+  try {
+    localStorage.setItem('gor:v1', JSON.stringify(state));
+  } catch (e) {
+    console.warn('Failed to save state', e);
+  }
+}

--- a/js/transform.js
+++ b/js/transform.js
@@ -1,0 +1,37 @@
+export function buildSeries(daily, humidity, wind, normals) {
+  return {
+    x: daily.date,
+    tempMin: daily.tmin,
+    tempMean: daily.tmean,
+    tempMax: daily.tmax,
+    precip: daily.precip,
+    humidity: humidity,
+    wind: wind,
+    norm: normals ? normals.tmeanNorm.slice(0, daily.date.length) : null
+  };
+}
+
+export function computeStats(series) {
+  const minT = Math.min(...series.tempMin);
+  const maxT = Math.max(...series.tempMax);
+  const avgT = avg(series.tempMean);
+  const precipTotal = sum(series.precip);
+  const precipDays = series.precip.filter(v => v > 0.1).length;
+  const precipMax = Math.max(...series.precip);
+  const humAvg = avg(series.humidity);
+  const windAvg = avg(series.wind);
+  const windMax = Math.max(...series.wind);
+  let climateDev = null;
+  if (series.norm) {
+    climateDev = avgT - avg(series.norm);
+  }
+  return { minT, maxT, avgT, climateDev, precipTotal, precipDays, precipMax, humAvg, windAvg, windMax };
+}
+
+function avg(arr) {
+  return arr.reduce((a,b)=>a+b,0)/(arr.length||1);
+}
+
+function sum(arr) {
+  return arr.reduce((a,b)=>a+b,0);
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,58 @@
+import { loadState, saveState } from './store.js';
+import { searchCity, fetchDaily, fetchHourly, dailyMeanFromHourly, fetchNormals } from './api.js';
+import { buildSeries, computeStats } from './transform.js';
+import { initCharts, renderAll } from './charts.js';
+import { exportPng } from './export.js';
+
+const state = loadState();
+const charts = initCharts();
+
+async function apply() {
+  const city = document.getElementById('city').value;
+  const start = document.getElementById('start').value;
+  const end = document.getElementById('end').value;
+  if (!city || !start || !end) return alert('Fill all fields');
+  try {
+    const geo = await searchCity(city);
+    const daily = await fetchDaily(geo.lat, geo.lon, start, end);
+    const hourly = await fetchHourly(geo.lat, geo.lon, start, end);
+    const hum = dailyMeanFromHourly(hourly.time, hourly.humidity);
+    const wind = dailyMeanFromHourly(hourly.time, hourly.wind);
+    let normals = null;
+    if (state.prefs.showNormals) {
+      try { normals = await fetchNormals(geo.lat, geo.lon); } catch (e) { normals = null; }
+    }
+    const series = buildSeries(daily, hum.means, wind.means, normals);
+    renderAll(charts, series, '#1E88E5', state.prefs);
+    const stats = computeStats(series);
+    fillStats(document.getElementById('stats'), stats);
+    state.entities = [{type:'city', name: geo.name, lat: geo.lat, lon: geo.lon, color:'#1E88E5'}];
+    state.date = {start, end};
+    saveState(state);
+  } catch (e) {
+    console.error(e);
+    alert(e.message);
+  }
+}
+
+export function bindControls() {
+  document.getElementById('apply').addEventListener('click', apply);
+  document.getElementById('export').addEventListener('click', () => exportPng('charts'));
+}
+
+export function fillStats(dom, stats) {
+  dom.innerHTML = `<table>
+  <tr><th>Min temp</th><td>${stats.minT.toFixed(1)} °C</td></tr>
+  <tr><th>Max temp</th><td>${stats.maxT.toFixed(1)} °C</td></tr>
+  <tr><th>Avg temp</th><td>${stats.avgT.toFixed(1)} °C</td></tr>
+  <tr><th>Climate dev</th><td>${stats.climateDev!==null?stats.climateDev.toFixed(1)+' °C':'n/a'}</td></tr>
+  <tr><th>Total precip</th><td>${stats.precipTotal.toFixed(1)} mm</td></tr>
+  <tr><th>Max daily precip</th><td>${stats.precipMax.toFixed(1)} mm</td></tr>
+  <tr><th>Days >0.1 mm</th><td>${stats.precipDays}</td></tr>
+  <tr><th>Avg humidity</th><td>${stats.humAvg.toFixed(1)} %</td></tr>
+  <tr><th>Avg wind</th><td>${stats.windAvg.toFixed(1)} km/h</td></tr>
+  <tr><th>Max wind</th><td>${stats.windMax.toFixed(1)} km/h</td></tr>
+  </table>`;
+}
+
+bindControls();


### PR DESCRIPTION
## Summary
- replace previous prototype with single-page layout using ECharts and local modules
- add Open-Meteo API utilities with climate normals and daily aggregation
- implement state persistence, chart rendering, and PNG export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c49ec2924833181fae7944c464d06