### PR TITLE
Adapt UI for mobile devices

### DIFF
--- a/about.html
+++ b/about.html
@@ -116,6 +116,30 @@
     .back-link:hover {
       text-decoration: underline;
     }
+
+    @media (max-width: 480px) {
+      body {
+        padding: 0.75rem 0.5rem;
+      }
+
+      .container {
+        padding: 1.25rem;
+      }
+
+      #content h1 {
+        font-size: 1.5rem;
+        margin-bottom: 1rem;
+      }
+
+      #content h2 {
+        font-size: 1.2rem;
+        margin-top: 1.5rem;
+      }
+
+      #content h3 {
+        font-size: 1rem;
+      }
+    }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>

--- a/js/charts.js
+++ b/js/charts.js
@@ -12,8 +12,11 @@ export function renderAll(ch, series, color = '#1E88E5', prefs = { showGrid: tru
   const tempRange = series.tempMax.map((max, i) => (isFiniteNumber(max) && isFiniteNumber(series.tempMin[i]) ? max - series.tempMin[i] : null));
   const windSeries = (series.windMax && series.windMax.length) ? series.windMax : series.wind;
   const windAxisMax = 200;
-  const gridTop = { left: 56, right: 32, top: 16, bottom: 24, containLabel: true };
-  const gridBottom = { left: 56, right: 32, top: 16, bottom: 24, containLabel: true };
+  const narrow = window.innerWidth <= 480;
+  const gridLeft = narrow ? 36 : 56;
+  const gridRight = narrow ? 12 : 32;
+  const gridTop = { left: gridLeft, right: gridRight, top: 16, bottom: 24, containLabel: true };
+  const gridBottom = { left: gridLeft, right: gridRight, top: 16, bottom: 24, containLabel: true };
 
   const smoothingActive = (prefs.smoothing || 0) > 0;
   const asterisk = smoothingActive ? '*' : '';
@@ -250,8 +253,11 @@ export function renderAll(ch, series, color = '#1E88E5', prefs = { showGrid: tru
 export function renderCompare(ch, allSeries, colors, prefs = { showGrid: true, smoothing: 0 }, labels = []) {
   const x = allSeries[0].x;
   const windAxisMax = 200;
-  const gridTop = { left: 56, right: 32, top: 16, bottom: 24, containLabel: true };
-  const gridBottom = { left: 56, right: 32, top: 16, bottom: 24, containLabel: true };
+  const narrow = window.innerWidth <= 480;
+  const gridLeft = narrow ? 36 : 56;
+  const gridRight = narrow ? 12 : 32;
+  const gridTop = { left: gridLeft, right: gridRight, top: 16, bottom: 24, containLabel: true };
+  const gridBottom = { left: gridLeft, right: gridRight, top: 16, bottom: 24, containLabel: true };
 
   const smoothingActive = (prefs.smoothing || 0) > 0;
   const asterisk = smoothingActive ? '*' : '';

--- a/js/ui.js
+++ b/js/ui.js
@@ -72,6 +72,12 @@ restoreProgressionInputs();
 showNoDataPlaceholder();
 autoApplyOnLoad();
 
+// Resize ECharts on window/orientation change
+window.addEventListener('resize', () => {
+  if (charts.temp) charts.temp.resize();
+  if (charts.hydro) charts.hydro.resize();
+});
+
 // --- Mode & Controls ---
 
 function setupModeSelector() {

--- a/styles.css
+++ b/styles.css
@@ -1108,3 +1108,217 @@ input[type="date"]::-webkit-datetime-edit-text {
 .kofi-panel.hidden {
   display: none;
 }
+
+/* ========================================
+   Mobile Adaptation
+   ======================================== */
+
+/* Touch-friendly targets for coarse pointer devices (phones, tablets) */
+@media (pointer: coarse) {
+  #controls select,
+  #controls input,
+  .city-search-input,
+  .auto-location-btn,
+  #controls button,
+  #controls .primary {
+    height: 40px;
+    min-height: 40px;
+    font-size: 0.85rem;
+  }
+
+  .auto-location-btn {
+    flex: 0 0 40px;
+    width: 40px;
+  }
+
+  .icon-btn {
+    width: 36px !important;
+    height: 36px !important;
+    min-width: 36px !important;
+  }
+
+  .icon-btn img {
+    width: 20px;
+    height: 20px;
+  }
+
+  .city-tag,
+  .year-tag {
+    padding: 0.35rem 0.5rem;
+    font-size: 0.8rem;
+  }
+
+  .city-tag-remove,
+  .year-tag-remove {
+    width: 20px;
+    height: 20px;
+    font-size: 0.8rem;
+  }
+
+  .city-option {
+    padding: 0.75rem;
+  }
+}
+
+/* Disable hover effects on touch devices */
+@media (hover: none) {
+  .city-tag:hover,
+  .year-tag:hover {
+    filter: none;
+  }
+
+  .kofi-floater:hover {
+    transform: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  #controls button:not(.primary):not(.danger):hover {
+    background: transparent;
+  }
+}
+
+/* Small phones (≤480px) */
+@media (max-width: 480px) {
+  body {
+    font-size: 13px;
+  }
+
+  #config-bar {
+    padding: 0.3rem;
+  }
+
+  #workspace {
+    padding: 0.3rem;
+    gap: 0.3rem;
+  }
+
+  #charts {
+    flex: none;
+    min-height: 300px;
+  }
+
+  .chart-card header {
+    padding: 0.3rem 0.5rem;
+    font-size: 0.7rem;
+  }
+
+  #panel {
+    overflow: visible;
+  }
+
+  #stats {
+    font-size: 0.75rem;
+    padding: 0.4rem;
+  }
+
+  #stats .stats-title {
+    font-size: 0.8rem;
+    padding: 0.4rem;
+  }
+
+  #stats .stats-label,
+  #stats .stats-value {
+    font-size: 0.75rem;
+  }
+
+  #stats .stats-row,
+  #stats .stats-header-row {
+    padding: 0.3rem;
+    gap: 0.3rem;
+  }
+
+  .controls-row {
+    gap: 0.35rem;
+  }
+
+  /* Full-width selectors on small phones */
+  #mode-selector,
+  #smoothing-selector {
+    flex: 1 1 calc(50% - 0.175rem);
+  }
+
+  /* Stack date inputs */
+  #start, #end {
+    flex: 1 1 calc(50% - 0.175rem) !important;
+    width: auto !important;
+    min-width: 0;
+  }
+
+  /* Apply button full width */
+  #apply {
+    flex: 1 1 100%;
+    order: 99;
+  }
+
+  /* Toast narrower on small screens */
+  .toast {
+    max-width: calc(100vw - 2rem);
+    padding: 0.75rem 1rem;
+    font-size: 0.8rem;
+    bottom: 1rem;
+    gap: 1rem;
+  }
+
+  .toast.toast-error {
+    max-width: calc(100vw - 2rem);
+  }
+
+  #toast-progress {
+    bottom: 4.5rem;
+  }
+
+  /* Ko-fi floater smaller on phones */
+  .kofi-floater {
+    width: 48px;
+    height: 48px;
+    bottom: 16px;
+    right: 16px;
+  }
+
+  .kofi-floater img {
+    width: 26px;
+    height: 26px;
+  }
+
+  /* Ko-fi panel full-width on small phones */
+  .kofi-panel {
+    bottom: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    max-width: 100vw;
+    height: calc(100vh - 72px);
+    max-height: calc(100vh - 72px);
+    border-radius: 12px 12px 0 0;
+  }
+
+  /* City dropdown wider */
+  .city-dropdown {
+    min-width: 250px;
+  }
+
+  footer {
+    padding: 0.5rem !important;
+    font-size: 0.7rem !important;
+  }
+}
+
+/* Landscape orientation on small devices */
+@media (max-height: 500px) and (orientation: landscape) {
+  #workspace {
+    flex-direction: row;
+  }
+
+  #charts {
+    flex: 1.618;
+    min-height: 0;
+  }
+
+  #panel {
+    max-width: 280px;
+  }
+
+  .chart-card header {
+    padding: 0.2rem 0.5rem;
+  }
+}


### PR DESCRIPTION
- Add ECharts resize handler for window/orientation changes
- Add touch-friendly targets (40px) via @media (pointer: coarse)
- Disable hover effects on touch devices via @media (hover: none)
- Add small phone breakpoint (≤480px) with compact layout
- Reduce chart grid margins on narrow screens
- Make Ko-fi panel full-width sheet on small phones
- Constrain toast width to viewport on mobile
- Improve landscape orientation layout for small devices
- Adapt about.html typography and spacing for phones

https://claude.ai/code/session_018kjugqRnJnawyEqiZL421G